### PR TITLE
Site navigation fixes

### DIFF
--- a/project_tier/events/templates/events/event_index_page.html
+++ b/project_tier/events/templates/events/event_index_page.html
@@ -5,10 +5,10 @@
   <div data-sticky-container>
     <div class="sticky" data-sticky data-sticky-on="large" data-margin-top="3" data-top-anchor="on-this-page:top" data-btm-anchor="main-end:bottom">
       <nav class="sidebar-nav article-nav">
-        <h3>On this page</h3>
+        <h3 id="on-this-page">On this page</h3>
         <ul class="vertical menu" data-magellan data-bar-offset="60">
-          <li><a href="/events">Upcoming events</a></li>
-          <li><a href="/events#past-events">Past events</a></li>
+          <li><a href="#upcoming-events">Upcoming events</a></li>
+          <li><a href="#past-events">Past events</a></li>
         </ul>
       </nav>
     </div>

--- a/project_tier/static/css/_sidebar-nav.scss
+++ b/project_tier/static/css/_sidebar-nav.scss
@@ -5,6 +5,12 @@
     margin-left: -20px;
     width: 25%;
   }
+
+  .menu > li a:hover,
+  .menu > li:hover a {
+    /* By default Foundation puts colored backgrounds here but they look ugly */
+    background: transparent;
+  }
 }
 .sidebar-nav {
   @include breakpoint(medium up) {

--- a/project_tier/templates/standard_sidebar_layout.html
+++ b/project_tier/templates/standard_sidebar_layout.html
@@ -32,3 +32,17 @@
   </main>
   <div id="main-end"></div>
 {% endblock %}
+
+{% block extra_js %}
+  <script>
+    $(document).ready(function() {
+      // Forces Magellan to activate on pageload if there's a hash in the URL.
+      // Otherwise the topnav covers the content.
+      // see: https://github.com/ProjectTIER/projecttier.org/issues/32
+      // TODO: Upgrading Foundation to the latest version might let us remove this.
+      if(window.location.hash.length > 0) {
+        $('.menu[data-magellan]').find('[href='+window.location.hash+']').click();
+      }
+    });
+  </script>
+{% endblock %}

--- a/project_tier/templates/tags/table_of_contents_menu.html
+++ b/project_tier/templates/tags/table_of_contents_menu.html
@@ -15,7 +15,7 @@
     <div class="sticky" data-sticky data-sticky-on="large" data-margin-top="3" data-top-anchor="on-this-page:top" data-btm-anchor="main-end:bottom">
       <nav class="sidebar-nav article-nav">
         <h3 id="on-this-page">On this page</h3>
-        <ul class="vertical menu" data-magellan data-bar-offset="60">
+        <ul class="vertical menu" data-magellan data-bar-offset="60" data-deep-linking="true">
           {% for heading in article_headings %}
             <li>
               <a href="#{{heading.value|slugify}}">{{heading.value}}</a>

--- a/project_tier/templates/tags/top_menu.html
+++ b/project_tier/templates/tags/top_menu.html
@@ -9,7 +9,7 @@
 </div>
 
 
-<div class="top-bar" id="work">
+<div class="top-bar" id="work" style="display:flex">
   <div class="top-bar-left">
     <a href="/" id="topbar-logo">{% include "includes/svg_logo.html" %}</a>
   </div>


### PR DESCRIPTION
This fixes #32 but also has additional fixes. Complete list of fixes below.

### 1. Anchored links now scroll to the right part of the screen when the page loads.

![screenshot from 2018-05-23 17 00 30](https://user-images.githubusercontent.com/3639540/40450968-2df253b6-5eab-11e8-9d36-a7d305575b9c.png)

---

### 2. On pages with sidebars, the URL will now change as you scroll through the page. This makes it easier copy the link and send the exact part of the page you're on to a peer.

No screenshot.

---

### 3. The left sidebar on the events page will now scroll along with you like it does on the other pages.

Before:
![screenshot from 2018-05-23 17 02 00](https://user-images.githubusercontent.com/3639540/40451060-6188255c-5eab-11e8-840f-ec6700bd5846.png)

After:
![screenshot from 2018-05-23 17 01 42](https://user-images.githubusercontent.com/3639540/40451061-61a95704-5eab-11e8-9ddc-88fe64df6fc8.png)


---

### 4. Clicking the left sidebar links in the event index page doesn't cause the page to reload anymore.

No screenshot.

---

### 5. Links in the sidebar would become unreadable on hover because of a weird gray background that's applied. This has been removed.

Before:
![screenshot from 2018-05-23 16 58 34](https://user-images.githubusercontent.com/3639540/40450920-0d90922c-5eab-11e8-80ef-6671796490c3.png)

After:
![screenshot from 2018-05-23 16 58 57](https://user-images.githubusercontent.com/3639540/40450919-0d76efe8-5eab-11e8-919a-cada207f1b61.png)

### 6. The top navigation bar would become glitchy when shrinking then expanding the window. This has now been fixed.

Before:
![screenshot from 2018-05-23 16 59 21](https://user-images.githubusercontent.com/3639540/40451132-933c080c-5eab-11e8-90be-94981b9ed80c.png)

After:
![screenshot from 2018-05-23 16 59 43](https://user-images.githubusercontent.com/3639540/40451131-932981be-5eab-11e8-8c80-7d97100d7513.png)
