### PR TITLE
Show fellow year range in the backend

### DIFF
--- a/project_tier/people/models.py
+++ b/project_tier/people/models.py
@@ -100,7 +100,9 @@ class PersonPage(Page):
 class FellowPersonPage(PersonPage):
     YEAR_CHOICES = []
     for r in range(2010, (datetime.datetime.now().year+1)):
-        YEAR_CHOICES.append((r, r))
+        YEAR_CHOICES.append(
+            (r, "{}–{}".format(r, r + 1))
+        )
 
     fellowship_year = models.IntegerField(
         choices=YEAR_CHOICES,


### PR DESCRIPTION
This changes the CMS to clearly show the year range for fellows.

![screenshot from 2018-06-18 17 54 22](https://user-images.githubusercontent.com/3639540/41564413-b2dcd93c-7320-11e8-9e76-4b237cedb81e.png)
