### PR TITLE
Enable analytics only when explicitly configured to

### DIFF
--- a/project_tier/core/templatetags/projecttier_tags.py
+++ b/project_tier/core/templatetags/projecttier_tags.py
@@ -1,5 +1,6 @@
 from django import template
 from django.urls import reverse
+from django.conf import settings
 
 register = template.Library()
 
@@ -7,3 +8,8 @@ register = template.Library()
 @register.filter
 def document_view_url(value):
     return reverse('view_document', args=[value.id, value.filename])
+
+
+@register.simple_tag
+def get_setting(name):
+    return getattr(settings, name, "")

--- a/project_tier/settings/base.py
+++ b/project_tier/settings/base.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = (
     'storages',
     'wagtailfontawesome',
     'wagtailemoji',
+    'wagalytics',
 
     'django.contrib.admin',
     'django.contrib.auth',
@@ -185,9 +186,11 @@ CELERYD_LOG_COLOR = False
 WAGTAIL_SITE_NAME = "project_tier"
 
 
-# Wagalytics
+# Analytics
+
+if 'ANALYTICS_ENABLED' in env:
+    ANALYTICS_ENABLED = env['ANALYTICS_ENABLED'].lower() in ['1', 'true']
 
 if 'GA_KEY_CONTENT' in env and 'GA_VIEW_ID' in env:
     GA_KEY_CONTENT = env['GA_KEY_CONTENT']
     GA_VIEW_ID = env['GA_VIEW_ID']
-    INSTALLED_APPS += ('wagalytics',)

--- a/project_tier/templates/base.html
+++ b/project_tier/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load navigation_tags compress static wagtailuserbar %}
+{% load navigation_tags compress static wagtailuserbar projecttier_tags %}
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
@@ -41,15 +41,18 @@
     {% endblock %}
   </head>
   <body class="{% block body_class %}{% endblock %}">
-    <!-- Google Tag Manager -->
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TTPSWS"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-TTPSWS');</script>
-    <!-- End Google Tag Manager -->
+    {% get_setting "ANALYTICS_ENABLED" as analytics_enabled %}
+    {% if not request.is_preview and analytics_enabled %}
+      <!-- Google Tag Manager -->
+        <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TTPSWS"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-TTPSWS');</script>
+      <!-- End Google Tag Manager -->
+    {% endif %}
     {% wagtailuserbar %}
     {% get_site_root as site_root %}
     {% top_menu parent=site_root calling_page=self %}


### PR DESCRIPTION
Disables analytics entirely unless ANALYTICS_ENABLED=1 is set. We'll set that on the production server to make sure that only the production server is reporting back, not the staging server or dev environment.