### PR TITLE
Update Protocol Tag header in Course Material Template

### DIFF
--- a/project_tier/course_materials/templates/course_materials/course_materials_index_page.html
+++ b/project_tier/course_materials/templates/course_materials/course_materials_index_page.html
@@ -41,7 +41,7 @@
 
         {% if protocol_tags %}
           <div class="tag-group">
-            <h6>Protocol</h6>
+            <h6>Software</h6>
             {% for tag in protocol_tags %}
               <div class="tag">
                 <label>


### PR DESCRIPTION
Protocol header on Course Materials page changed to "Software", as requested by TIER. 