### PR TITLE
Bug fixes for TIER Network + upgrade dependencies

### DIFF
--- a/project_tier/settings/base.py
+++ b/project_tier/settings/base.py
@@ -80,6 +80,7 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
 
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',

--- a/project_tier/settings/production.py
+++ b/project_tier/settings/production.py
@@ -52,7 +52,7 @@ if 'CACHE_PURGE_URL' in env:
         },
     }
 
-STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 # STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 # Compress static files offline and minify CSS
 # http://django-compressor.readthedocs.org/en/latest/settings/#django.conf.settings.COMPRESS_OFFLINE

--- a/project_tier/standard/models.py
+++ b/project_tier/standard/models.py
@@ -11,7 +11,12 @@ class StandardIndexPage(Page):
     title_suffix = models.CharField(help_text="Additional text to display after the page title e.g. '(Version 3.0)", max_length=255, blank=True)
     listing_abstract = models.TextField(help_text='Give a brief blurb (about 1 sentence) of what this topic is about. It will appear on other pages that refer to this one.', blank=True)
     introductory_headline = models.TextField(help_text='Introduce the topic of this page in 1-3 sentences.', blank=True)
-    body = StreamField(LimitedStreamBlock(), blank=True)
+    body = StreamField(
+        LimitedStreamBlock(
+            required=False  # https://github.com/wagtail/wagtail/issues/4306#issuecomment-384099847
+        ),
+        blank=True
+    )
 
     @property
     def children(self):

--- a/project_tier/static/css/_topbar.scss
+++ b/project_tier/static/css/_topbar.scss
@@ -61,7 +61,7 @@ body.scrolled .top-bar {
       }
 
     }
-    
+
   @include breakpoint(xlarge) {
     padding-left: 4.5rem;
   }
@@ -76,7 +76,6 @@ body.scrolled .top-bar {
 .menu {
   background: none;
   > li {
-    text-transform: uppercase;
     box-shadow: none;
   @include breakpoint(735){
     padding: $small-gutter/2 $medium-gutter/8 0;

--- a/project_tier/wsgi.py
+++ b/project_tier/wsgi.py
@@ -10,8 +10,6 @@ import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project_tier.settings.production")
 
-from whitenoise.django import DjangoWhiteNoise
 from django.core.wsgi import get_wsgi_application
 
 application = get_wsgi_application()
-application = DjangoWhiteNoise(application)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ dj-database-url==0.5.0
 wagtailfontawesome==1.1.3
 wagtailemoji==1.0.2
 wagtailatomicadmin==0.2.5
-wagalytics==0.7
+wagalytics==1.0rc1
 psycopg2==2.7.5
 whitenoise==4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-wagtail==2.0.1
-boto==2.48.0
-celery==4.1.0
+wagtail==2.2.2
+boto==2.49.0
+celery==4.2.1
 django_compressor==2.2
 django-storages==1.6.6
 djangorestframework==3.8.2
@@ -11,12 +11,12 @@ wagtailfontawesome==1.1.3
 wagtailemoji==1.0.2
 wagtailatomicadmin==0.2.5
 wagalytics==0.7
-psycopg2==2.7.4
-whitenoise==3.3.1
+psycopg2==2.7.5
+whitenoise==4.0
 
 # Heroku webserver
-gunicorn==19.7.1
+gunicorn==19.9.0
 
 # Tests
 django-nose==1.4.5
-factory_boy==2.10.0
+factory_boy==2.11.1


### PR DESCRIPTION
1. Upgrades project dependencies to latest versions. This required updating the settings for WhiteNoise.
2. Makes the top navigation text normal case (instead of forced to uppercase). This allows enough room to put the "TIER Network" nav item.
3. The body field in Standard Index Pages was required (due to a bug), and workaround has been put in place to make the field not required.
4. Upgrade Wagalytics to v1.0rc1