### PR TITLE
Hide Network Other category from Person List Page (aka People Page)

### DIFF
--- a/project_tier/network/models.py
+++ b/project_tier/network/models.py
@@ -155,6 +155,10 @@ class PersonListPage(Page):
         sections = []
         categories = Person.CATEGORIES
         for category in categories:
+
+            if category[0] == 'network_other':
+                continue
+
             # Get people for category
             people = self.people.filter(category=category[0])
             if people:


### PR DESCRIPTION
Individuals of the "Network Other" category should ONLY show on Network Index pages, not Person List Pages which are reserved for Fellows, PDs, and Advisory Board.