### PR TITLE
Clarify filter language on materials and exercise index pages (+bug fixes)

### DIFF
--- a/project_tier/course_materials/models.py
+++ b/project_tier/course_materials/models.py
@@ -195,10 +195,12 @@ class CourseMaterialsIndexPage(Page):
         # Info about page results
         course_materials_count = context['course_materials'].count()
         hidden_course_materials = CourseMaterialsPage.objects.count() - course_materials_count
+        total_course_materials = CourseMaterialsPage.objects.count()
         context['results'] = {
             'shown': course_materials_count,
             'hidden': hidden_course_materials,
-            'filtered': hidden_course_materials > 0
+            'filtered': hidden_course_materials > 0,
+            'total': total_course_materials
         }
 
         return context

--- a/project_tier/course_materials/models.py
+++ b/project_tier/course_materials/models.py
@@ -142,7 +142,7 @@ class CourseMaterialsIndexPage(Page):
     def get_context(self, request):
         context = super().get_context(request)
 
-        context['course_materials'] = CourseMaterialsPage.objects.child_of(self).live()
+        context['course_materials'] = CourseMaterialsPage.objects.child_of(self).live().order_by('-first_published_at')
 
         # Filters tags by type (using reverse accessors).
         # eg. `Tag.course_materials_disciplinetag_items` will contain rows if

--- a/project_tier/course_materials/templates/course_materials/course_materials_index_page.html
+++ b/project_tier/course_materials/templates/course_materials/course_materials_index_page.html
@@ -68,7 +68,32 @@
   <div class="course-materials-list row">
     <div class="body-content">
       {% if results.filtered %}
-        <p class="filter-text">{{ results.hidden }} course material{{ results.hidden|pluralize:" is,s are" }} hidden. <a href="{{ page.url }}">Clear filters <i class="fa fa-times"></i></a></p>
+        {# 7 number of results match your filters: XXX, X, XXX. View all 21983  #}
+        {# <p class="filter-text">{{ results.hidden }} course material{{ results.hidden|pluralize:" is,s are" }} hidden. <a href="{{ page.url }}">Clear filters <i class="fa fa-times"></i></a></p> #}
+
+        <p class="filter-text">{{ results.shown }} of {{ results.total }} total results match your filters:
+          {% if discipline_tags_checked %}
+            {% for tag in discipline_tags_checked %}
+              <span class="tag-indicator">{{ tag }}</span>
+            {% endfor %}
+          {% endif %}
+
+          {% if course_level_tags_checked %}
+            {% for tag in course_level_tags_checked %}
+              <span class="tag-indicator">{{ tag }}</span>
+            {% endfor %}
+          {% endif %}
+
+          {% if protocol_tags_checked %}
+            {% for tag in protocol_tags_checked %}
+              <span class="tag-indicator">{{ tag }}</span>
+            {% endfor %}
+          {% endif %}
+          
+          <a href="{{ page.url }}">Clear all filters <i class="fa fa-times"></i></a>
+        </p>
+
+
       {% else %}
         <p class="filter-text">{{ results.shown }} course{{ results.shown|pluralize}} found.</p>
       {% endif %}

--- a/project_tier/course_materials/templates/course_materials/course_materials_index_page.html
+++ b/project_tier/course_materials/templates/course_materials/course_materials_index_page.html
@@ -67,10 +67,8 @@
 {% block main_content %}
   <div class="course-materials-list row">
     <div class="body-content">
-      {% if results.filtered %}
-        {# 7 number of results match your filters: XXX, X, XXX. View all 21983  #}
-        {# <p class="filter-text">{{ results.hidden }} course material{{ results.hidden|pluralize:" is,s are" }} hidden. <a href="{{ page.url }}">Clear filters <i class="fa fa-times"></i></a></p> #}
 
+      {% if results.filtered %}
         <p class="filter-text">{{ results.shown }} of {{ results.total }} total results match your filters:
           {% if discipline_tags_checked %}
             {% for tag in discipline_tags_checked %}
@@ -89,10 +87,9 @@
               <span class="tag-indicator">{{ tag }}</span>
             {% endfor %}
           {% endif %}
-          
+
           <a href="{{ page.url }}">Clear all filters <i class="fa fa-times"></i></a>
         </p>
-
 
       {% else %}
         <p class="filter-text">{{ results.shown }} course{{ results.shown|pluralize}} found.</p>

--- a/project_tier/exercises/models.py
+++ b/project_tier/exercises/models.py
@@ -158,7 +158,7 @@ class ExerciseIndexPage(Page):
     def get_context(self, request):
         context = super().get_context(request)
 
-        context['exercises'] = ExercisePage.objects.child_of(self).live()
+        context['exercises'] = ExercisePage.objects.child_of(self).live().order_by('-first_published_at')
 
         # Filters tags by type (using reverse accessors).
         # eg. `Tag.exercises_disciplinetag_items` will contain rows if

--- a/project_tier/exercises/models.py
+++ b/project_tier/exercises/models.py
@@ -200,10 +200,12 @@ class ExerciseIndexPage(Page):
         # Info about page results
         exercises_count = context['exercises'].count()
         hidden_exercises = ExercisePage.objects.count() - exercises_count
+        total_exercises = ExercisePage.objects.count()
         context['results'] = {
             'shown': exercises_count,
             'hidden': hidden_exercises,
-            'filtered': hidden_exercises > 0
+            'filtered': hidden_exercises > 0,
+            'total': total_exercises
         }
 
         return context

--- a/project_tier/exercises/templates/exercises/exercise_index_page.html
+++ b/project_tier/exercises/templates/exercises/exercise_index_page.html
@@ -68,7 +68,29 @@
   <div class="exercise-list row">
     <div class="body-content">
       {% if results.filtered %}
-        <p class="filter-text">{{ results.hidden }} exercise{{ results.hidden|pluralize:" is,s are" }} hidden. <a href="{{ page.url }}">Clear filters <i class="fa fa-times"></i></a></p>
+
+      <p class="filter-text">{{ results.shown }} of {{ results.total }} total results match your filters:
+        {% if discipline_tags_checked %}
+          {% for tag in discipline_tags_checked %}
+            <span class="tag-indicator">{{ tag }}</span>
+          {% endfor %}
+        {% endif %}
+
+        {% if course_level_tags_checked %}
+          {% for tag in course_level_tags_checked %}
+            <span class="tag-indicator">{{ tag }}</span>
+          {% endfor %}
+        {% endif %}
+
+        {% if protocol_tags_checked %}
+          {% for tag in protocol_tags_checked %}
+            <span class="tag-indicator">{{ tag }}</span>
+          {% endfor %}
+        {% endif %}
+
+        <a href="{{ page.url }}">Clear all filters <i class="fa fa-times"></i></a>
+      </p>
+
       {% else %}
         <p class="filter-text">{{ results.shown }} exercise{{ results.shown|pluralize}} found.</p>
       {% endif %}

--- a/project_tier/network/templates/network/includes/person_list.html
+++ b/project_tier/network/templates/network/includes/person_list.html
@@ -10,7 +10,7 @@
 
     <div class="course-materials-list row">
       <div class="body-content">
-      <div class="materials cards">
+      <div class="materials people cards">
 
         {% for person in list %}
 

--- a/project_tier/network/templates/network/includes/person_list.html
+++ b/project_tier/network/templates/network/includes/person_list.html
@@ -2,38 +2,42 @@
 
 <section class="block-section">
    <div class="row">
+
     <div class="section-intro small-12">
       <h2 class="section-title">{{group}}</h2>
     </div>
-    <div class="small-12">
-      <ul class="item-list person-list row small-up-1 medium-up-2 large-up-3" data-equalizer>
 
-      {% for person in list %}
-         <li class="column">
-          <a href="/person/{{person.slug}}">
-            <article class="person list-item" data-equalizer-watch>
 
-            {% if person.image %}
-              {% image person.image fill-280x280-c100 as photo %}
-              <img src="{{ photo.url }}" width="{{ photo.width }}" height="{{ photo.height }}" alt="{{ photo.alt }}" class="img-thumbnail" />
+    <div class="course-materials-list row">
+      <div class="body-content">
+      <div class="materials cards">
 
-            {% else %}
-              <img class="placeholder img-thumbnail" />
+        {% for person in list %}
 
-            {% endif %}
+          <div class="card">
+            <a href="/person/{{person.slug}}">
+              {% if person.image %}
+                {% image person.image fill-280x280-c100 as photo %}
+                <img src="{{ photo.url }}" width="{{ photo.width }}" height="{{ photo.height }}" alt="{{ photo.alt }}" class="img-thumbnail" />
 
-            <div class="title text-center">
-              <h2>{{ person.first_name }} {{ person.last_name }}{% if person.academic_title %},<span class="academic-title"> {{ person.academic_title }}</span>{% endif %}</h2>
-              <h4>{{ person.main_job_title }}</h4>
-              <h4>{{ person.affiliation }}</h4>
+              {% else %}
+                <img class="placeholder img-thumbnail" />
+
+              {% endif %}
+            </a>
+
+            <div class="card-divider">
+                <h2>{{ person.first_name }} {{ person.last_name }}{% if person.academic_title %},<span class="academic-title"> {{ person.academic_title }}</span>{% endif %}</h2>
             </div>
-          </article>
-          </a>
-        </li>
+            <div class="card-section">
+              <p><strong>{{ person.main_job_title }}</strong></p>
+              <p>{{ person.affiliation }}<p>
+            </div>
+          </div>
 
-      {% endfor %}
+        {% endfor %}
 
-       </ul>
+      </div>
     </div>
   </div>
 </section>

--- a/project_tier/network/templates/network/person_list_page.html
+++ b/project_tier/network/templates/network/person_list_page.html
@@ -6,7 +6,7 @@
     <div class="sticky" data-sticky data-sticky-on="large" data-margin-top="3" data-top-anchor="on-this-page:top" data-btm-anchor="main-end:bottom">
       <nav class="sidebar-nav section-nav">
         <h3 id="on-this-page">In this section</h3>
-        <ul class="vertical menu" data-magellan data-bar-offset="60">
+        <ul class="vertical menu" data-magellan data-bar-offset="100">
 
           {% for section in self.sections %}
             <li class="{% if section.category.is_active %}is-active{% endif %}">

--- a/project_tier/network/templates/network/person_list_page.html
+++ b/project_tier/network/templates/network/person_list_page.html
@@ -24,10 +24,8 @@
  {% block main_content %}
 
   {% if self.body %}
-    <div class="row">
-      <div class="body-content">
-        {{ self.body|richtext }}
-      </div>
+    <div class="body-content">
+      {{ self.body|richtext }}
     </div>
   {% endif %}
 

--- a/project_tier/static/css/_exercises.scss
+++ b/project_tier/static/css/_exercises.scss
@@ -25,6 +25,23 @@
   margin: 0.5em 0 1.25rem 0;
 }
 
+.tag-indicator {
+  color: #a32428;
+}
+
+.tag-indicator:after {
+  content: ", ";
+  color: #8c8c8c;
+}
+
+.tag-indicator:last-of-type:after {
+  content: "";
+}
+
+.tag-indicator:last-of-type {
+  padding-right: 7px;
+}
+
 .tags .tag {
   background-color: #ececec;
   text-decoration: none;

--- a/project_tier/static/css/_people.scss
+++ b/project_tier/static/css/_people.scss
@@ -130,3 +130,7 @@ ul.accordion .accordion-content ul li.column::before {
   margin-left: -25px;
   margin-top: -10px;
 }
+
+.people .section-intro {
+  margin-top: 20px;
+}

--- a/project_tier/static/css/_people.scss
+++ b/project_tier/static/css/_people.scss
@@ -137,7 +137,7 @@ ul.accordion .accordion-content ul li.column::before {
 
 .card .img-thumbnail {
     background-color: $grey;
-    margin: 0 0 20px 0;
+    margin: 0 0 0px 0;
     width: 100%;
     height: auto;
     float: none;

--- a/project_tier/static/css/_people.scss
+++ b/project_tier/static/css/_people.scss
@@ -124,3 +124,9 @@ ul.accordion .accordion-content ul li.column::before {
   width: 75%;
   margin: 0 auto;
 }
+
+.people {
+  width: 100%;
+  margin-left: -25px;
+  margin-top: -10px;
+}

--- a/project_tier/static/css/_people.scss
+++ b/project_tier/static/css/_people.scss
@@ -134,3 +134,19 @@ ul.accordion .accordion-content ul li.column::before {
 .people .section-intro {
   margin-top: 20px;
 }
+
+
+.card .img-thumbnail {
+    background-color: $grey;
+    margin: 0 0 20px 0;
+    width: 100%;
+    height: auto;
+    float: none;
+
+    @include breakpoint(medium) {
+        float: left;
+        width: auto;
+        min-width: 280px;
+        min-height: 280px;
+    }
+}

--- a/project_tier/static/css/_people.scss
+++ b/project_tier/static/css/_people.scss
@@ -126,7 +126,6 @@ ul.accordion .accordion-content ul li.column::before {
 }
 
 .people {
-  width: 100%;
   margin-left: -25px;
   margin-top: -10px;
 }


### PR DESCRIPTION
- Improve filter language for clarity
![screenshot from 2018-09-19 13 07 13](https://user-images.githubusercontent.com/17955536/45777617-51156000-bc24-11e8-9c56-557dfff9f2ce.png)

- People cards now look like course and exercise cards:
![screenshot from 2018-09-19 15 56 03](https://user-images.githubusercontent.com/17955536/45777692-88840c80-bc24-11e8-89a1-e57b7e470c34.png)

- Course Materials and Exercises sort by most recent by default now