### PR TITLE
order CM cards by more recent update

### DIFF
--- a/project_tier/course_materials/models.py
+++ b/project_tier/course_materials/models.py
@@ -142,7 +142,7 @@ class CourseMaterialsIndexPage(Page):
     def get_context(self, request):
         context = super().get_context(request)
 
-        context['course_materials'] = CourseMaterialsPage.objects.child_of(self).live().order_by('-first_published_at')
+        context['course_materials'] = CourseMaterialsPage.objects.child_of(self).live().order_by('-latest_revision_created_at')
 
         # Filters tags by type (using reverse accessors).
         # eg. `Tag.course_materials_disciplinetag_items` will contain rows if

--- a/project_tier/settings/base.py
+++ b/project_tier/settings/base.py
@@ -191,7 +191,7 @@ WAGTAIL_SITE_NAME = "project_tier"
 # Taggit
 # https://django-taggit.readthedocs.io/en/latest/
 
-TAGGIT_CASE_INSENSITIVE = True
+# TAGGIT_CASE_INSENSITIVE = True
 
 
 # Analytics


### PR DESCRIPTION
- Order CM cards by `-latest_revision_created_at` rather than `first_published_at`
- Remove Taggit Case Insensitive for now