### PR TITLE
Disable TAGGIT_CASE_INSENSITIVE

### DIFF
--- a/project_tier/settings/base.py
+++ b/project_tier/settings/base.py
@@ -191,7 +191,9 @@ WAGTAIL_SITE_NAME = "project_tier"
 # Taggit
 # https://django-taggit.readthedocs.io/en/latest/
 
-# TAGGIT_CASE_INSENSITIVE = True
+# Just query tags in a case-insensitive way instead.
+# https://github.com/alex/django-taggit/issues/448
+TAGGIT_CASE_INSENSITIVE = False
 
 
 # Analytics


### PR DESCRIPTION
We're already querying tags in a case-insensitive way - there is no need to have this option enabled. All it does is crashes certain pages when they're edited, so I'm disabling it.