### PR TITLE
BROKER_URL = 'redis://' is actually required

### DIFF
--- a/project_tier/settings/base.py
+++ b/project_tier/settings/base.py
@@ -178,6 +178,8 @@ COMPRESS_PRECOMPILERS = (
 # When you have multiple sites using the same Redis server,
 # specify a different Redis DB. e.g. redis://localhost/5
 
+BROKER_URL = 'redis://'
+
 CELERY_SEND_TASK_ERROR_EMAILS = True
 CELERYD_LOG_COLOR = False
 


### PR DESCRIPTION
For running redis in dev