### PR TITLE
Upgrade Wagtail, remove djangorestframework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,27 @@
 language: python
 
+dist: xenial
+sudo: true
+
 services:
   - postgresql
+
+addons:
+  postgresql: "10"
 
 python:
   - "3.6"
 
 env:
-  - DATABASE_URL="postgres://postgres@localhost:5432/projecttier"
+  global:
+    - DATABASE_URL="postgres://postgres@localhost:5432/projecttier"
 
 install:
   - pip install -r requirements.txt
   - pip install coveralls
 
 before_script:
-  - psql -c 'create database projecttier;' -d postgres -U postgres
+  - psql -c 'create database projecttier;' -U postgres
 
 script:
   - coverage run --source='.' manage.py test project_tier

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "torchbox/wagtail-jessie64"
+  config.vm.box = "torchbox/wagtail-stretch64"
   config.vm.box_version = "~> 1.0"
 
   # Disable automatic box update checking. If you disable this, then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-wagtail==2.2.2
+wagtail==2.3
 boto==2.49.0
 celery==4.2.1
 django_compressor==2.2
 django-storages==1.7.1
-djangorestframework==3.8.2
 django-libsass==0.7
 django_redis==4.9.0
 dj-database-url==0.5.0

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -10,6 +10,10 @@ PYTHON=$VIRTUALENV_DIR/bin/python
 PIP=$VIRTUALENV_DIR/bin/pip
 
 
+# Upgrade postgres to 10 to match Heroku and TravisCI
+apt update && apt-get install postgresql-client-10
+
+
 # Create database
 set +e
 su - vagrant -c "createdb $PROJECT_NAME"

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+set -xe
 
 PROJECT_NAME=$1
 
@@ -9,16 +10,11 @@ PYTHON=$VIRTUALENV_DIR/bin/python
 PIP=$VIRTUALENV_DIR/bin/pip
 
 
-# Upgrade postgres
-echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-apt update
-apt install -y postgresql-9.5
-ln -s /usr/lib/postgresql/9.5/bin/pg_dump /usr/bin/pg_dump --force
-
-
 # Create database
+set +e
 su - vagrant -c "createdb $PROJECT_NAME"
+set -e
+
 
 
 # Virtualenv setup for project
@@ -43,7 +39,7 @@ su - vagrant -c "$PYTHON $PROJECT_DIR/manage.py migrate --noinput && \
 
 
 # Install Heroku toolbelt
-apt install -y openssl
+apt-get install -y openssl
 su - vagrant -c  "wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh"
 
 


### PR DESCRIPTION
Looks like Rest Framework isn't actually used, removing it so we don't get bothered by requires.io