### PR TITLE
 Shrink size of Academic Title for Network cards 

### DIFF
--- a/project_tier/network/models.py
+++ b/project_tier/network/models.py
@@ -80,6 +80,9 @@ class Person(models.Model):
         joined = self.joined_on
         return joined and (today - joined).days <= 30
 
+    def __str__(self):
+        return '{} {}'.format(self.first_name, self.last_name)
+
     panels = [
         MultiFieldPanel(
             [

--- a/project_tier/static/css/_people.scss
+++ b/project_tier/static/css/_people.scss
@@ -179,6 +179,12 @@ ul.accordion .accordion-content ul li.column::before {
   .job-title {
     font-weight: normal;
   }
+  span.academic-title {
+    font-weight: normal;
+    font-size: 1em;
+    color: black;
+    opacity: 1;
+  }
   .new::before {
     content: 'new';
     text-transform: uppercase;


### PR DESCRIPTION
Fixes #98 

![screenshot from 2019-02-17 14 36 11](https://user-images.githubusercontent.com/3639540/52918125-9caa6380-32c1-11e9-9a66-5c432c4d19ed.png)

Also adds the `__str__` method to Person objects, which fixes the way they're identified in the Wagtail admin. Just a small issue I noticed while fixing the other one.