### PR TITLE
Enable links to be copy/pasted into the tip body

### DIFF
--- a/draftailmodal/forms.py
+++ b/draftailmodal/forms.py
@@ -18,7 +18,7 @@ class TipForm(forms.Form):
             # Use an editor with limited features to avoid modals within modals
             # and other funny stuff.
             features=[
-                'h2', 'h3', 'bold', 'italic', 'ol', 'ul',
+                'h2', 'h3', 'bold', 'italic', 'ol', 'ul', 'link',
                 # 'link', 'image', 'embed'  # FIXME: These don't work
             ]
         )

--- a/draftailmodal/wagtail_hooks.py
+++ b/draftailmodal/wagtail_hooks.py
@@ -4,6 +4,7 @@ from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleE
 from wagtail.admin.rich_text.converters.html_to_contentstate import InlineEntityElementHandler
 from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
 from wagtail.core import hooks
+from wagtail.core.templatetags.wagtailcore_tags import richtext
 from draftjs_exporter.dom import DOM
 from django.urls import path, include
 from . import urls
@@ -65,6 +66,7 @@ def tip_entity_decorator(props):
     tip_html = ContentstateConverter(features=[
         'h2', 'h3', 'bold', 'italic', 'ol', 'ul', 'link', 'image', 'embed'
     ]).to_database_format(tip)
+    tip_html = richtext(tip_html)  # apply |richtext filter
     return DOM.create_element('span', {
         'data-tip': tip_html,
     }, props['children'])


### PR DESCRIPTION
Addresses the first bullet point of #82.

This is a short-term fix we agreed upon because of problems with the ideal solution in the Wagtail admin UI.

After this PR, links can be copied/cut from another RichTextField, then pasted into the tip body. Please do not try creating a link directly in the tip body, nor directing editing any link in the tip body, as this will cause the admin panel to freeze.

However, this is a solution that *does* work for the end-user.