### PR TITLE
Allow setting tip title

### DIFF
--- a/draftailmodal/static/js/tip.js
+++ b/draftailmodal/static/js/tip.js
@@ -147,9 +147,10 @@ class TipSource extends React.Component {
     }
 
     // Uses the Draft.js API to create a new entity with the right data.
-    const contentWithEntity = content.createEntity(entityType.type, 'IMMUTABLE', {
+    const contentWithEntity = content.createEntity(entityType.type, 'MUTABLE', {
         tip: tip_data,
     });
+    console.log(contentWithEntity);
     const entityKey = contentWithEntity.getLastCreatedEntityKey();
 
     // We also add some text for the entity to be activated on.

--- a/draftailmodal/wagtail_hooks.py
+++ b/draftailmodal/wagtail_hooks.py
@@ -77,7 +77,7 @@ class TipEntityElementHandler(InlineEntityElementHandler):
     Database HTML to Draft.js ContentState.
     Converts the span tag into a tip entity, with the right data.
     """
-    mutability = 'IMMUTABLE'
+    mutability = 'MUTABLE'
 
     def get_attribute_data(self, attrs):
         """


### PR DESCRIPTION
This addresses one of the bullet points in #82. The tip title can be edited by moving the cursor inside it with the arrow keys on the keyboard, inserting text, then removing any extraneous characters.

Example:

![screenshot from 2019-02-28 16 31 04](https://user-images.githubusercontent.com/3639540/53600024-88465080-3b76-11e9-8591-6d6f1357120f.png)
