### PR TITLE
Implement 'tip color' capability

### DIFF
--- a/draftailmodal/forms.py
+++ b/draftailmodal/forms.py
@@ -3,18 +3,30 @@ from wagtail.admin.rich_text import get_rich_text_editor_widget
 
 
 class TipForm(forms.Form):
-    """
-    ModalWorkflow popup form that lets you enter the tip text.
-    """
+    """ModalWorkflow popup form that lets you enter the tip text."""
+
+    color = forms.ChoiceField(choices=(
+        ('', 'default'),
+        ('red', 'red'),
+        ('blue', 'blue'),
+        ('green', 'green'),
+        ('yellow', 'yellow'),
+        ('orange', 'orange'),
+        ('purple', 'purple'),
+        ('grey', 'grey'),
+        ('black', 'black'),
+    ), required=False)
     tip_content = forms.CharField()  # main text field
-    entity_key = forms.CharField(required=False, widget=forms.HiddenInput)  # pass the entityKey on edit
+    # pass the entityKey on edit
+    entity_key = forms.CharField(required=False, widget=forms.HiddenInput)
 
     def __init__(self, *args, **kwargs):
+        """Configure the form fields."""
         super(TipForm, self).__init__(*args, **kwargs)
 
         # HACK: Set the widget when the form is initialized because otherwise
         # it doesn't work (for unknown reasons) ??
-        self.fields['tip_content'].widget=get_rich_text_editor_widget(
+        self.fields['tip_content'].widget = get_rich_text_editor_widget(
             # Use an editor with limited features to avoid modals within modals
             # and other funny stuff.
             features=[

--- a/draftailmodal/static/css/tip.css
+++ b/draftailmodal/static/css/tip.css
@@ -25,3 +25,29 @@
 .field.hidden_input {
   display: none;
 }
+
+/* Colors */
+.Draftail-inline--TIP[data-color="red"] {
+  background-color: #a32428;
+}
+.Draftail-inline--TIP[data-color="blue"] {
+  background-color: #1d7ac9;
+}
+.Draftail-inline--TIP[data-color="green"] {
+  background-color: #22851d;
+}
+.Draftail-inline--TIP[data-color="yellow"] {
+  background-color: #a49924;
+}
+.Draftail-inline--TIP[data-color="orange"] {
+  background-color: #a45d24;
+}
+.Draftail-inline--TIP[data-color="purple"] {
+  background-color: #501d6e;
+}
+.Draftail-inline--TIP[data-color="grey"] {
+  background-color: grey;
+}
+.Draftail-inline--TIP[data-color="black"] {
+  background-color: black;
+}

--- a/draftailmodal/static/js/tip.js
+++ b/draftailmodal/static/js/tip.js
@@ -191,6 +191,7 @@ const Tip = (props) => {
     return React.createElement('a', {
         role: 'button',
         className: 'Draftail-inline--TIP',
+        'data-color': data['color'],
         onMouseUp: () => {
             // When a tip is clicked, edit it.
             props.onEdit(entityKey);

--- a/draftailmodal/static/js/tip.js
+++ b/draftailmodal/static/js/tip.js
@@ -103,7 +103,8 @@ class TipSource extends React.Component {
       const data = contentState.getEntity(entityKey).getData();
       urlParams = {
         data: JSON.stringify(data['tip']),
-        entityKey: entityKey
+        entityKey: entityKey,
+        color: data['color']
       };
     } catch(err) {}
 
@@ -133,13 +134,14 @@ class TipSource extends React.Component {
   // Called when tip content has been entered and saved
   onChosen(data) {
     const tip_data = data['result'];
+    const color = data['color'];
     const { editorState, entityType, onComplete } = this.props;
     const content = editorState.getCurrentContent();
     const selection = editorState.getSelection();
 
     // Update an entity (if it exists). Happens when an entity is clicked.
     if (data.entityKey) {
-      const newContent = content.replaceEntityData(data.entityKey, {tip: tip_data});
+      const newContent = content.replaceEntityData(data.entityKey, {tip: tip_data, color: color});
       const nextState = EditorState.push(editorState, newContent, 'insert-characters');
       this.workflow.close();
       onComplete(nextState);
@@ -149,6 +151,7 @@ class TipSource extends React.Component {
     // Uses the Draft.js API to create a new entity with the right data.
     const contentWithEntity = content.createEntity(entityType.type, 'MUTABLE', {
         tip: tip_data,
+        color: color,
     });
     console.log(contentWithEntity);
     const entityKey = contentWithEntity.getLastCreatedEntityKey();

--- a/draftailmodal/views.py
+++ b/draftailmodal/views.py
@@ -17,6 +17,7 @@ def chooser(request):
         # A tip is being edited, fill in the form
         form = forms.TipForm({
             'tip_content': request.GET.get("data"),
+            'color': request.GET.get("color"),
             'entity_key': request.GET.get("entityKey")
         })
     else:
@@ -29,7 +30,8 @@ def chooser(request):
         json_data={
             'step': 'tip_chosen',
             'result': json.loads(tip),
-            'entityKey': request.POST.get("entity_key")
+            'entityKey': request.POST.get("entity_key"),
+            'color': request.POST.get("color"),
         }
 
     # Render the JSON data!

--- a/draftailmodal/wagtail_hooks.py
+++ b/draftailmodal/wagtail_hooks.py
@@ -90,4 +90,5 @@ class TipEntityElementHandler(InlineEntityElementHandler):
         ]).from_database_format(attrs['data-tip'])
         return {
             'tip': json.loads(tip_json),
+            'color': attrs['data-color'],
         }

--- a/draftailmodal/wagtail_hooks.py
+++ b/draftailmodal/wagtail_hooks.py
@@ -57,6 +57,7 @@ def tip_entity_decorator(props):
     Converts the tip entities into a span tag.
     """
     tip = props['tip']
+    color = props['color']
 
     # HACK: Convert to JSON string if necessary.
     # Without this it's inconsistent for some reason.
@@ -69,6 +70,7 @@ def tip_entity_decorator(props):
     tip_html = richtext(tip_html)  # apply |richtext filter
     return DOM.create_element('span', {
         'data-tip': tip_html,
+        'data-color': color,
     }, props['children'])
 
 

--- a/project_tier/static/css/main.scss
+++ b/project_tier/static/css/main.scss
@@ -103,10 +103,35 @@
     border-radius: 9999px;
     color: white;
     cursor: pointer;
+    white-space: nowrap;
 }
 [data-tip]::before {
     content: '\1F6C8';
     margin-right: 3px;
     transform: translateY(-1px);
     display: inline-block;
+}
+[data-tip][data-color="red"] {
+  background-color: #a32428;
+}
+[data-tip][data-color="blue"] {
+  background-color: #1d7ac9;
+}
+[data-tip][data-color="green"] {
+  background-color: #22851d;
+}
+[data-tip][data-color="yellow"] {
+  background-color: #a49924;
+}
+[data-tip][data-color="orange"] {
+  background-color: #a45d24;
+}
+[data-tip][data-color="purple"] {
+  background-color: #501d6e;
+}
+[data-tip][data-color="grey"] {
+  background-color: grey;
+}
+[data-tip][data-color="black"] {
+  background-color: black;
 }


### PR DESCRIPTION
Now tips have several colors to choose from. In the Wagtail page editor:

![Screenshot from 2019-03-19 19 50 22](https://user-images.githubusercontent.com/3639540/54649387-60188600-4a80-11e9-81c1-edb9be110bbe.png)

And on the page:

![Screenshot from 2019-03-19 19 46 04](https://user-images.githubusercontent.com/3639540/54649390-64dd3a00-4a80-11e9-9426-7e7e435bec7d.png)
