### PR TITLE
Fix template typo

### DIFF
--- a/project_tier/network/templates/network/person_detail.html
+++ b/project_tier/network/templates/network/person_detail.html
@@ -16,8 +16,7 @@
           {% if object.tier_title %}
             {{ object.tier_title }}
           {% else %}
-            {{ object.categories.first.tier_title }}
-            {% if object.fellowship_year %}, {{ object.fellowship_year }}{% endif %}
+            {{ object.categories.first.tier_title }}{% if object.fellowship_year %}, {{ object.fellowship_year }}{% endif %}
           {% endif %}
         </div>
 


### PR DESCRIPTION
There was an unwanted extra space before the comma.