### PR TITLE
Restore Lato as main body font

### DIFF
--- a/project_tier/specs/templates/specs_layout.html
+++ b/project_tier/specs/templates/specs_layout.html
@@ -2,6 +2,9 @@
 {% load projecttier_tags %}
 
 {% block body_class %}specs-section{% endblock %}
+{% block extra_css %}
+  <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Titillium+Web:400,300,400italic,700,700italic,900,900italic,300italic">
+{% endblock %}
 {% block page_banner %}{% endblock %}
 
 {% block sidebar %}

--- a/project_tier/static/css/_foundation_settings.scss
+++ b/project_tier/static/css/_foundation_settings.scss
@@ -59,7 +59,7 @@ $black: #0a0a0a;
 $white: #fefefe;
 $body-background: #A32428;
 $body-font-color: $black;
-$body-font-family: "Titillium Web", "Lato", Arial, sans-serif;
+$body-font-family: "Lato", Arial, sans-serif;
 $body-antialiased: true;
 $global-margin: 1rem;
 $global-padding: 1rem;

--- a/project_tier/static/css/_specs.scss
+++ b/project_tier/static/css/_specs.scss
@@ -1,5 +1,6 @@
 body.specs-section {
   background: #fefefe;
+  font-family: "Titillium Web", "Lato", Arial, sans-serif;
 }
 
 body.specs-section .main-wrap {

--- a/project_tier/static/css/_tier_settings.scss
+++ b/project_tier/static/css/_tier_settings.scss
@@ -29,7 +29,7 @@
    TYPOGRAPHY
    ========================================================================== */
 
-   $body-font-family: "Titillium Web", "Lato", Arial, sans-serif;
+   $body-font-family: "Lato", Arial, sans-serif;
    $header-font-family: 'Playfair Display', serif;
    $header-font-weight: bold;
 

--- a/project_tier/templates/base.html
+++ b/project_tier/templates/base.html
@@ -32,7 +32,7 @@
     <meta name="msapplication-config" content="{% static 'icons/browserconfig.xml' %}">
     <meta name="theme-color" content="#a32428">
     <!-- Styles -->
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Titillium+Web:400,300,400italic,700,700italic,900,900italic,300italic|Roboto+Mono:400,700italic,400italic,700|Playfair+Display:400,700">
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Lato:400,300,400italic,700,700italic,900,900italic,300italic|Roboto+Mono:400,700italic,400italic,700|Playfair+Display:400,700">
     {% compress css %}
       {% fontawesome_css %}
       <link rel="stylesheet" type="text/x-scss" href="{% static 'css/main.scss' %}">


### PR DESCRIPTION
This MR restores Lato as the body font of the main site, while retaining Titillium Web in the specs section.