### PR TITLE
4.0 Protocol Specs Section small style improvements

### DIFF
--- a/project_tier/static/css/_specs.scss
+++ b/project_tier/static/css/_specs.scss
@@ -316,3 +316,37 @@ body.specs-section {
 }
 
 .specs-pagination__page {}
+
+.specs-body ul.accordion {
+  list-style: none;
+  margin-left: 0;
+  color: #222222;
+  background-color: white;
+  border: none;
+  margin-bottom: 44px;
+
+  li {
+    list-style: none;
+    margin: 0;
+    border-bottom: 1px solid #e6e6e6;
+    padding: 20px 20px 20px 0;
+
+    .accordion-content {
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+
+    a.accordion-title {
+      color: #222222;
+      font-family: 'Titillium Web', sans-serif;
+      font-size: 1.375rem;
+      font-weight: 700;
+      border-bottom: none;
+      padding: 0;
+    }
+
+    a:before {
+      color: #222222;
+    }
+  }
+}

--- a/project_tier/static/css/_specs.scss
+++ b/project_tier/static/css/_specs.scss
@@ -267,6 +267,7 @@ body.specs-section {
 
   h3, h4, h5, h6 {
     font-family: 'Titillium Web', sans-serif;
+    max-width: 575px;
   }
 
   h3 {

--- a/project_tier/static/css/_specs.scss
+++ b/project_tier/static/css/_specs.scss
@@ -278,6 +278,10 @@ body.specs-section {
     margin-top: 40px;
   }
 
+  ul, ol {
+    margin-left: 20px;
+  }
+
   ul > li {
     list-style-type: square;
     margin: 20px 0 20px 20px;

--- a/project_tier/templates/blocks/smaller_heading.html
+++ b/project_tier/templates/blocks/smaller_heading.html
@@ -1,1 +1,1 @@
-<h4>{{self}}</h4>
+<h4 id="{{self|slugify}} data-magellan-target="{{self|slugify}}">{{self}}</h4>

--- a/project_tier/templates/blocks/smallest_heading.html
+++ b/project_tier/templates/blocks/smallest_heading.html
@@ -1,1 +1,1 @@
-<h5>{{self}}</h5>
+<h5 id="{{self|slugify}} data-magellan-target="{{self|slugify}}>{{self}}</h5>


### PR DESCRIPTION
- Fixes #204 
- Fixes #205
- Fixes #206 
- Fixes #208 

**Screenshot of indented bullets:**

![Screenshot from 2020-10-07 13 03 30](https://user-images.githubusercontent.com/17955536/95370079-e16f7d80-089d-11eb-84a7-816573e4d19e.png)

**Screenshots of accordion styles:**

(BEFORE)
![Screenshot from 2020-10-07 12 36 51](https://user-images.githubusercontent.com/17955536/95370136-f3e9b700-089d-11eb-8a11-5cb8d4ac1614.png)

(AFTER)
I only changed these for the specs section, so hopefully won't impact other areas where accordions are used. Also, accordions are already assigned IDs that are used in the logic for open/closing them, so I don't want to fuss with the IDs there. I think we can just show Rich and Norm how to access those IDs from the inspector if they want to link directly to an accordion item.

![Screenshot from 2020-10-07 12 59 00](https://user-images.githubusercontent.com/17955536/95370161-ff3ce280-089d-11eb-8a07-76d7329cda62.png)

![Screenshot from 2020-10-07 12 59 14](https://user-images.githubusercontent.com/17955536/95370171-02d06980-089e-11eb-9b31-47075735b0e4.png)