### PR TITLE
Update mailing list to new format

### DIFF
--- a/project_tier/static/css/_footer.scss
+++ b/project_tier/static/css/_footer.scss
@@ -135,18 +135,6 @@
   }
 }
 
-/* Mailing list */
-#newsletter-section * {
-  max-width: 100%;
-}
-#newsletter-section > .row {
-  margin: 0;
-  color: $light-grey;
-  > .footer-title h2::before {
-    content: "\f003";
-  }
-}
-
 .footer-title {
   h2 {
     color: $off-white;
@@ -162,15 +150,6 @@
 }
 .footer-description p {
   color: $light-grey;
-}
-.mailchimp-signup {
-  padding-left: 0;
-  .button {
-    padding: 10px 20px 9px 20px;
-    &:hover {
-      color: $dark-red;
-    }
-  }
 }
 
 #twitter-section {
@@ -211,13 +190,22 @@
 .block-section.promo {
   margin: 20px 0 40px 0;
 
+  .row {
+    margin-bottom: 40px;
+  }
+
   .graphic {
     margin-left: 30px;
-    margin-bottom: 30px;
+    margin-bottom: 10px;
   }
 
   .footer-title h2 {
     margin-top: 0;
+
+    .fa.email-icon {
+      font-size: 24px;
+      padding: 5px;
+    }
   }
 
   a.button {

--- a/project_tier/templates/includes/mailchimp_signup.html
+++ b/project_tier/templates/includes/mailchimp_signup.html
@@ -1,41 +1,11 @@
-<section id="newsletter-section">
+<!-- <section id="newsletter-section">
   <div class="row"><div class="small-12 footer-title">
    <h2>
-    Signup for e-mail updates 
+    Stay informed!
   </h2>
-</div>
-
-  <!-- Begin MailChimp Signup Form -->
-  <div class="small-12 columns end mailchimp-signup">
-  <div id="mc_embed_signup">
-    <form action="//projecttier.us12.list-manage.com/subscribe/post?u=bbf6900548eb5f9ed7866820a&amp;id=5416e37df2" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-      <div id="mc_embed_signup_scroll">
-
-        <div class="input-group mc-field-group">
-          <input type="email" value="" name="EMAIL" placeholder="Enter your email address" class="input-group-field required email" id="mce-EMAIL">
-          <div class="input-group-button">
-            <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
-          </div>
-        </div>
-
-        <div id="mce-responses" class="clear">
-          <div class="response" id="mce-error-response" style="display:none"></div>
-          <div class="response" id="mce-success-response" style="display:none"></div>
-        </div>
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px;" aria-hidden="true">
-          <input type="text" name="b_bbf6900548eb5f9ed7866820a_5416e37df2" tabindex="-1" value="">
-        </div>
-      </div>
-      </div>
-    </form>
-  </div>
-</div>
-
-<div class="row">
+  <a class="button" href="https://mailchi.mp/6d0b524f6da4/projecttierorg" target="_blank">Sign up for email updates</a>
   <div class="footer-description mailchimp-description">
     <p>Get updates on changes to the Protocols, upcoming events, and new programs.</p>
   </div>
 </div>
-<!--End mc_embed_signup-->
-</section>
+</section> -->

--- a/project_tier/templates/includes/main_footer.html
+++ b/project_tier/templates/includes/main_footer.html
@@ -9,7 +9,6 @@
               {% include "includes/twitter_section.html" %}
             </div>
           <div class="small-12 large-5 small-center columns mailchimp">
-              {% include "includes/mailchimp_signup.html" %}
               {% include "includes/promo.html" %}
           </div>
         </div>

--- a/project_tier/templates/includes/promo.html
+++ b/project_tier/templates/includes/promo.html
@@ -5,6 +5,15 @@
   <section class="block-section promo">
     <div class="row">
       <div class="large-12 columns">
+        <div class="small-12 footer-title"><h2><i class="fa fa-envelope-o email-icon"></i> Get Updates</h2></div>
+        <div class="footer-description"><p>Get updates on changes to the TIER Protocol, upcoming events, and new programs.</p></div>
+        <a class="button" href="https://mailchi.mp/6d0b524f6da4/projecttierorg" target="_blank">Subscribe to email updates</a>
+      </div>
+      <div class="large-1 columns"></div>
+    </div>
+
+    <div class="row">
+      <div class="large-12 columns">
         <div class="small-2 columns graphic float-right">
           {% image homepage.specific.promo_image width-200 %}
         </div>
@@ -14,5 +23,6 @@
       </div>
       <div class="large-1 columns"></div>
     </div>
+
   </section>
 {% endif %}


### PR DESCRIPTION
Fixes #203 

I had to change this up a bit because Rich and Norm requested that new users coming through the website had the "TIERList" tag added to them in Mailchimp. However, Mailchimp only supports adding tags to contacts via a specific form if you use their "Landing Page" tool (see their docs [here](https://mailchimp.com/help/getting-started-tags/#Things_to_know)). So, I created a Landing Page with all the required fields that adds the requested tag.

**View the new landing page here:** https://mailchi.mp/6d0b524f6da4/projecttierorg. 

The problem is that this prevents us from using the embed form like we were doing, so I updated the footer to just have a CTA button to direct users to the landing page. Here's how it looks now:

![Screenshot from 2020-10-07 14 34 41](https://user-images.githubusercontent.com/17955536/95378966-52b52d80-08aa-11eb-8be1-bc54874f93ca.png)

Also commented out and removed some mailchimp-specific code.

One nice thing about this solution is that you can also independently send someone directly to this signup form, and you can edit it in Mailchimp directly rather than getting us to edit the code any time you want to make a change to your email signup form.

Hope this solution is okay by everyone! If not, let me know and we can consider alternatives (the most obvious alternative being to use an embed form and give up on the tag).