### PR TITLE
Add SiteMiddleware back, fixes broken person pages

### DIFF
--- a/project_tier/settings/base.py
+++ b/project_tier/settings/base.py
@@ -85,6 +85,7 @@ MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
 
+    'wagtail.contrib.legacy.sitemiddleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 )
 


### PR DESCRIPTION
SiteMiddleware was [deprecated in Wagtail 2.11](https://docs.wagtail.io/en/stable/releases/2.11.html#sitemiddleware-moved-to-wagtail-contrib-legacy). I thought we weren't using it so I removed it, but it turns out it's needed for rendering the site URL on certain pages. Wagtail still ships it, it's just renamed `wagtail.contrib.legacy.sitemiddleware.SiteMiddleware`, so I added it back. Now person pages won't be broken. If there's a better way to render the site URL we should use that in the future, but for now this is fine.