### PR TITLE
Sponsor text: fix sizing and width

### DIFF
--- a/project_tier/static/css/_footer.scss
+++ b/project_tier/static/css/_footer.scss
@@ -37,7 +37,8 @@
     .joining-text {
       display: inline-block;
       color: $white;
-      max-width: 6em;
+      max-width: 14em;
+      font-size: 15px;
       text-align: left;
       line-height: 1;
     }


### PR DESCRIPTION
Improves the style of the sponsorship text in the footer:

![Screenshot from 2021-07-11 22-53-36](https://user-images.githubusercontent.com/3639540/125228691-dcab8000-e29a-11eb-9ad7-3070d6497de5.png)
