### PR TITLE
Specs: fix accordion link visibility

### DIFF
--- a/project_tier/static/css/_specs.scss
+++ b/project_tier/static/css/_specs.scss
@@ -358,6 +358,17 @@ body.specs-section {
     .accordion-content {
       border-bottom: none;
       padding-bottom: 0;
+
+      a {
+        color: #1d7ac9;
+        text-decoration: underline;
+        transition: color 0.2s, box-shadow 0.2s;
+
+        &:hover,
+        &:active {
+          color: #a32428;
+        }
+      }
     }
 
     a.accordion-title {


### PR DESCRIPTION
Fixes the visibility of links in accordions on specs pages:

![Screenshot from 2021-08-22 12-22-43](https://user-images.githubusercontent.com/3639540/130364226-ada182ad-ec48-48a9-902e-eb9c1366b6a5.png)
