### PR TITLE
Vagrant: upgrade to Postgres 13

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -13,7 +13,7 @@ def deploy_production():
 
 def pull_staging_data():
     local('psql -d project_tier -c "ALTER USER vagrant with password \'vagrant\';"')
-    local('dropdb project_tier')
+    local('dropdb --if-exists project_tier')
     local('heroku pg:pull DATABASE_URL project_tier --app projecttier-staging')
     local('psql -d project_tier -c "alter role vagrant password null;"')
 
@@ -22,7 +22,7 @@ def pull_production_data():
     # It will prompt you to log in to Heroku. Your Heroku user needs adequate
     # permission on the projecttier-production app.
     local('psql -d project_tier -c "ALTER USER vagrant with password \'vagrant\';"')
-    local('dropdb project_tier')
+    local('dropdb --if-exists project_tier')
     local('heroku pg:pull DATABASE_URL project_tier --app projecttier-production')
     local('psql -d project_tier -c "alter role vagrant password null;"')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ dj-database-url==0.5.0
 wagtailfontawesome==1.2.1
 wagtailemoji==1.0.2
 wagtailatomicadmin==0.2.5
-psycopg2==2.8.5
+psycopg2==2.9.3
 whitenoise==5.0.1
 wagtail-linkchecker==0.5.1
 Unidecode==1.2.0

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -11,9 +11,9 @@ PIP=$VIRTUALENV_DIR/bin/pip
 
 
 # Upgrade postgres to 13 to match Heroku
-apt update && apt-get install -y postgresql-13 postgresql-client-13
-cp /etc/postgresql/9.6/main/pg_hba.conf /etc/postgresql/13/main/pg_hba.conf
 pg_dropcluster 9.6 main --stop
+apt update && apt-get install -y postgresql-13 postgresql-client-13
+sudo -Hu postgres psql -c "CREATE ROLE vagrant WITH LOGIN CREATEDB SUPERUSER"
 
 
 # Create database
@@ -46,7 +46,7 @@ su - vagrant -c "$PYTHON $PROJECT_DIR/manage.py migrate --noinput && \
 
 # Install Heroku toolbelt
 apt-get install -y openssl
-su - vagrant -c  "wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh"
+su - vagrant -c  "curl https://cli-assets.heroku.com/install-ubuntu.sh | sh"
 
 
 # Install s3cmd for copying media files from S3-compatible services

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -10,8 +10,10 @@ PYTHON=$VIRTUALENV_DIR/bin/python
 PIP=$VIRTUALENV_DIR/bin/pip
 
 
-# Upgrade postgres to 10 to match Heroku and TravisCI
-apt update && apt-get install -y postgresql-client-10
+# Upgrade postgres to 13 to match Heroku
+apt update && apt-get install -y postgresql-13 postgresql-client-13
+cp /etc/postgresql/9.6/main/pg_hba.conf /etc/postgresql/13/main/pg_hba.conf
+pg_dropcluster 9.6 main --stop
 
 
 # Create database


### PR DESCRIPTION
Upgrades to Posgres 13 so the environment in Vagrant matches Heroku.