### PR TITLE
Fix homepage split banner section styles on large and small screens

### DIFF
--- a/project_tier/static/css/_blocks.scss
+++ b/project_tier/static/css/_blocks.scss
@@ -561,6 +561,7 @@ ul.accordion {
       max-width: 80% !important;
       height: auto !important;
       margin-bottom: -100px;
+      margin-top: 40px;
 
       iframe {
         width: 100%;
@@ -586,6 +587,58 @@ ul.accordion {
         padding-right: 20px;
       }
     }
+  }
+}
+
+@media(min-width: 1500px) {
+  .split_banner_section {
+    display: flex;
+    align-items: center;
+    position: relative;
+    margin: 20px 0;
+    overflow: hidden;
+
+    &__banner {
+      background-image: linear-gradient(90deg, $dark-red, $red);
+      overflow: hidden;
+      margin: 40px auto 40px 0;
+      width: 80% !important;
+      height: 460px;
+      clip-path: polygon(0 0, 100% 0%, 85% 100%, 0% 100%);
+    }
+
+    .split_banner_section__text {
+      padding: 40px 60px;
+      padding-left: 10%;
+      padding-right: 20%;
+      margin-right: 0;
+      margin-right: 160px;
+    }
+
+    .split_banner_section__text.right {
+      padding: 40px 60px;
+      padding-right: 10% !important;
+      padding-left: 20% !important;
+      margin-right: 0;
+      margin-left: 160px !important;
+    }
+
+    .split_banner_section__image-container {
+      position: absolute;
+      left: 60%;
+      right: auto;
+      width: 600px;
+      height: 350px;
+    }
+
+    .split_banner_section__image-container.right {
+      position: absolute;
+      left: auto;
+      right: 60% !important;
+      width: 600px;
+      height: 350px;
+    }
+
   }
 }
 


### PR DESCRIPTION
**Previous**
Small screens:
![Screenshot from 2022-05-16 14 23 31](https://user-images.githubusercontent.com/17955536/168667066-f019a4dd-4219-4393-a422-1389e2969d87.png)

Extra large screens:
![Screenshot from 2022-05-16 14 22 52](https://user-images.githubusercontent.com/17955536/168667070-8959d118-5a03-45f5-a982-98be1db7b52b.png)



**New**
Small screens (added gap):
![Screenshot from 2022-05-16 14 23 46](https://user-images.githubusercontent.com/17955536/168667097-0ceb752c-26c7-43a6-b934-6cf1df30a6da.png)

Extra large screens (extended banner to fill screen):
![Screenshot from 2022-05-16 14 23 09](https://user-images.githubusercontent.com/17955536/168667100-8cad3656-0fc0-4eb0-afd0-e051cc1ad5fb.png)
